### PR TITLE
[FIX] #62 - Avoid sending summary on the weekend, etc

### DIFF
--- a/timesheet_reminder_mail/data/reminder_cron.xml
+++ b/timesheet_reminder_mail/data/reminder_cron.xml
@@ -24,7 +24,7 @@
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
             <field eval="False" name="doall" />
-            <field name="nextcall" eval="datetime.utcnow()" />
+            <field name="nextcall" eval="(datetime.utcnow() + timedelta(days=1)).strftime('%Y-%m-%d 14:55:00')" />
         </record>
     </data>
 </odoo>

--- a/timesheet_reminder_mail/i18n/fr.po
+++ b/timesheet_reminder_mail/i18n/fr.po
@@ -145,3 +145,18 @@ msgstr ""
 "        % endif\n"
 "    </div>\n"
 "            "
+
+#. module: timesheet_reminder_mail
+#: model:ir.actions.server,name:timesheet_reminder_mail.cron_timesheet_summary_manager_ir_actions_server
+#: model:ir.cron,cron_name:timesheet_reminder_mail.cron_timesheet_summary_manager
+#: model:ir.cron,name:timesheet_reminder_mail.cron_timesheet_summary_manager
+#: model:mail.template,subject:timesheet_reminder_mail.mail_template_timesheet_summary_manager
+msgid "Daily summary of time spent"
+msgstr "Résumé quotidien des temps passés"
+
+#. module: timesheet_reminder_mail
+#: model:ir.actions.server,name:timesheet_reminder_mail.cron_reminder_timesheet_ir_actions_server
+#: model:ir.cron,cron_name:timesheet_reminder_mail.cron_reminder_timesheet
+#: model:ir.cron,name:timesheet_reminder_mail.cron_reminder_timesheet
+msgid "Reminder to fill timesheet"
+msgstr "Rappel pour saisir tes temps"

--- a/timesheet_reminder_mail/views/mail.xml
+++ b/timesheet_reminder_mail/views/mail.xml
@@ -99,7 +99,7 @@
     
         <!-- Ajout d'un template mail pour la synthèse des temps passés journalier à envoyer au manager -->
         <record id="mail_template_timesheet_summary_manager" model="mail.template">
-            <field name="name">Timesheet - Daily summary of time spent</field>
+            <field name="name">Timesheet: Daily summary of time spent</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="email_from">${(object.company_id.partner_id.email_formatted or object.email_formatted) |safe}</field>
             <field name="email_to">${object.work_email | safe}</field>


### PR DESCRIPTION
-  Ne pas envoyer de mail le weekend
-  Traduire les termes restants (notamment le sujet du mail)
-  Programmer le cron `cron_timesheet_summary_manager` pour 16h55